### PR TITLE
Better command structure.

### DIFF
--- a/cmd/general/help.js
+++ b/cmd/general/help.js
@@ -11,7 +11,7 @@ class Help extends require("../../commandClass"){
     run(message,bot,args){
         const {MessageEmbed} = require("discord.js");
         if(args.length > 0){
-            let cmd = bot.commands.find(c => c.getName() === args[0]);
+            let cmd = bot.commands.get(args[0]);
             if(args.length === 1 && cmd){
                 checkCommand(cmd);
             } else if(cmd){
@@ -21,7 +21,7 @@ class Help extends require("../../commandClass"){
             }
         } else {
             let str = "";
-            bot.commands.map(c => {
+            bot.commands.forEach(c => {
                 str += "**" + c.getName() + "** - " + c.getHelp().base + "\n";
             });
             let embed = constructEmbed([

--- a/commands.js
+++ b/commands.js
@@ -1,13 +1,13 @@
 module.exports.get = () => {
     const {readdirSync} = require("fs");
-    let tempArr = [];
+    const commands = new Map();
     readdirSync("./cmd").forEach(f => {
         if(!f.endsWith(".js")){
             readdirSync("./cmd/" + f).forEach(ff => {
                 if(ff.endsWith(".js")){
                     let js = require("./cmd/" + f + "/" + ff);
                     if(js instanceof require("./commandClass")){
-                        tempArr.push(js);
+                        commands.set(js.getName(), js);
                     } else {
                         console.log("Non-command file in folder " + f + ": " + ff);
                     }
@@ -19,5 +19,5 @@ module.exports.get = () => {
             console.log("JS files in the cmd folder, why???");
         }
     });
-    return tempArr;
+    return commands;
 }

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ bot.on("message", message => {
     if(!message.content.startsWith(bot.prefix)) return;
     const args = message.content.slice(bot.prefix.length).split(" ");
     const command = args.shift().toLowerCase();
-    const cmd = bot.commands.find(c => c.getName() === command);
+    const cmd = bot.commands.get(command);
     if(cmd){ cmd.run(message,bot,args); }
 });
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "main": "main.js",
   "dependencies": {
     "discord.js": "^12.5.1"
   }


### PR DESCRIPTION
A map offers the _get_ function which does essentially the same things as `array.find(a=>a.getName()===command)`. In addition, a map is iterable which means that the _help_ command isn't limited by this change. Also adding `"main": "main.js"` to package.json does no harm either.